### PR TITLE
Read coordinate system status before motor positions

### DIFF
--- a/pmacApp/pmacAsynCoordSrc/pmacAsynCoord.c
+++ b/pmacApp/pmacAsynCoordSrc/pmacAsynCoord.c
@@ -621,6 +621,9 @@ static void drvPmacGetAxesStatus( PMACDRV_ID pDrv, epicsUInt32 *status)
     first_axis = &pDrv->axis[0];
     last_axis = &pDrv->axis[NAXES-1];
     
+    /* Get the co-ordinate system status */
+    drvPmacGetCoordStatus(first_axis, pDrv->pasynUser, status);
+
     /* Read all the positions for this co-ordinate system in one go */
     sprintf( command, "&%d", first_axis->coord_system);
     for (i = first_axis->axis; i <= last_axis->axis; i++) {
@@ -629,9 +632,6 @@ static void drvPmacGetAxesStatus( PMACDRV_ID pDrv, epicsUInt32 *status)
     }
 
     cmdStatus = motorAxisWriteRead( first_axis, command, sizeof(pos_response), pos_response, 1 );
-
-    /* Get the co-ordinate system status */
-    drvPmacGetCoordStatus(first_axis, pDrv->pasynUser, status);
 
     for (i = 0; i < NAXES; i++) {
         pAxis = &pDrv->axis[i];


### PR DESCRIPTION
Read the CS (coordinate system) status before reading the motor positions so that the CS in-position status is consistent with the motor positions.  The CS in-position status is used to set the `motorAxisMoving` and `motorAxisDone` parameters of the Asyn motors of the coordinate system.  If the CS status is read *after* the motor positions are read, there's a small window of time where the motor position of an Asyn motor could be *not* in-position (i.e., the position would not be considered in-position by the PMAC controller), but the done-moving flag of the Asyn motor could be true.  To avoid this, read the CS status *before* reading the motor positions.

The unfavorable sequence of events is:

 1. The motor is moving toward the commanded position.
 2. The motor position is read, and the position is not in-position yet.
 3. The motor reaches the commanded position and is in-position.
 4. The CS status is read and the in-position flag is true.
 5. The Asyn motor is marked as done-moving.

At this point, the Asyn motor is in the done-moving state, but its readback position is the motor position that was last read (in step 2) which is not in-position.  The Asyn motor position will be updated at the next driver status poll event, but the Asyn motor is in an inconsistent state until then.

This inconsistent state can be unexpected from a caller's perspective when moving a motor via the EPICS motor record.  Consider a caller that expects to be able to move the motor and, after waiting for the move to finish, to read the readback value and have it be a value that the PMAC controller would consider to be in-position.  If the caller checks that the motor moved to where it was commanded to move by comparing the readback position with the commanded position, it could see a readback position that is not considered to be in-position by the PMAC controller, and at the same time see that the motor done-moving flag is true (i.e., the move finished) which is a contradiction.  By reordering the CS-status read and the motor-positions read such that the CS status is read first, the EPICS motor record readback position will be more consistent with its done-moving flag.